### PR TITLE
Оповещение о дне рождения

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
 
+    implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.clubhouse">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application
+        android:name=".ContactApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -12,12 +16,22 @@
         <activity android:name="com.example.clubhouse.ui.activities.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name="@string/birthday_notification_action" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
         <service android:name=".ui.services.ContactService" />
+        <service android:name=".ui.services.BirthdayNotificationService" />
+        <service android:name=".ui.services.RebootReminderService" />
+
+        <receiver android:name=".ui.receivers.ContactBirthdayReceiver">
+            <intent-filter>
+                <action android:name="@string/birthday_action" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/clubhouse/data/BirthDate.kt
+++ b/app/src/main/java/com/example/clubhouse/data/BirthDate.kt
@@ -1,0 +1,18 @@
+package com.example.clubhouse.data
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.util.*
+
+@Parcelize
+data class BirthDate(
+    val day: Int,
+    val month: Int
+) : Parcelable {
+    val timeInMillis
+        get() = Calendar.getInstance().apply {
+            set(0, month, day)
+        }.timeInMillis
+
+    fun isLeap() = day == 29 && month == 1
+}

--- a/app/src/main/java/com/example/clubhouse/data/ContactEntity.kt
+++ b/app/src/main/java/com/example/clubhouse/data/ContactEntity.kt
@@ -5,8 +5,10 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class ContactEntity(
+    val id: Int,
     val name: String,
     val phoneNumbers: List<String>,
     val emails: List<String>,
-    val description: String
+    val description: String,
+    val birthDate: BirthDate
 ) : Parcelable

--- a/app/src/main/java/com/example/clubhouse/data/Extensions.kt
+++ b/app/src/main/java/com/example/clubhouse/data/Extensions.kt
@@ -1,6 +1,12 @@
 package com.example.clubhouse.data
 
+import java.util.*
+
 fun ContactEntity.toSimple() = SimpleContactEntity(
     name,
     phoneNumbers.firstOrNull()
 )
+
+fun Calendar.isLeap() = get(Calendar.YEAR).let {
+    it % 4 == 0 && (it % 100 != 0 || it % 400 == 0)
+}

--- a/app/src/main/java/com/example/clubhouse/data/MockDataSource.kt
+++ b/app/src/main/java/com/example/clubhouse/data/MockDataSource.kt
@@ -4,16 +4,22 @@ object MockDataSource {
     private const val name = "Имя"
     private const val firstPhoneNumber = "89000000000"
 
-    fun getContacts(): List<SimpleContactEntity> {
+    fun getSimpleContacts(): List<SimpleContactEntity> {
         return listOf(SimpleContactEntity(name, firstPhoneNumber))
+    }
+
+    fun getContacts(ids: IntArray): List<ContactEntity> {
+        return listOf(getContact(1))
     }
 
     fun getContact(id: Int): ContactEntity {
         return ContactEntity(
+            1,
             name,
             listOf(firstPhoneNumber, "89123456789"),
             listOf("email@for.test", "another@one.email"),
-            "Описание контакта"
+            "Описание контакта",
+            BirthDate(28, 5)
         )
     }
 }

--- a/app/src/main/java/com/example/clubhouse/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/activities/MainActivity.kt
@@ -1,23 +1,25 @@
 package com.example.clubhouse.ui.activities
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import com.example.clubhouse.R
-import com.example.clubhouse.ui.fragments.CONTACT_DETAILS_FRAGMENT_TAG
-import com.example.clubhouse.ui.fragments.CONTACT_LIST_FRAGMENT_TAG
-import com.example.clubhouse.ui.fragments.ContactDetailsFragment
-import com.example.clubhouse.ui.fragments.ContactListFragment
+import com.example.clubhouse.ui.fragments.*
 import com.example.clubhouse.ui.interfaces.ContactCardClickListener
 import com.example.clubhouse.ui.interfaces.ContactServiceConsumer
 import com.example.clubhouse.ui.interfaces.ContactServiceOwner
 import com.example.clubhouse.ui.services.ContactService
 import kotlin.properties.Delegates
+
+const val CONTACT_ARG_NULL_VALUE = -1
 
 private const val FRAGMENT_TAG_KEY = "fragment_tag"
 
@@ -46,6 +48,7 @@ class MainActivity : AppCompatActivity(), ContactCardClickListener, ContactServi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        createNotificationChannel()
 
         bindService(
             Intent(this, ContactService::class.java),
@@ -66,6 +69,15 @@ class MainActivity : AppCompatActivity(), ContactCardClickListener, ContactServi
 
                 CONTACT_LIST_FRAGMENT_TAG
             }
+
+        intent?.getIntExtra(
+            CONTACT_ARG_ID,
+            CONTACT_ARG_NULL_VALUE
+        )?.let {
+            if (it != CONTACT_ARG_NULL_VALUE) {
+                onCardClick(it)
+            }
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -112,4 +124,17 @@ class MainActivity : AppCompatActivity(), ContactCardClickListener, ContactServi
         } else {
             null
         }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            (getSystemService(NOTIFICATION_SERVICE) as NotificationManager)
+                .createNotificationChannel(NotificationChannel(
+                    getString(R.string.birthday_channel_id),
+                    getString(R.string.birthday_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT
+                ).apply {
+                    description = getString(R.string.birthday_channel_description)
+                })
+        }
+    }
 }

--- a/app/src/main/java/com/example/clubhouse/ui/delegates/ReminderDelegate.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/delegates/ReminderDelegate.kt
@@ -1,0 +1,161 @@
+package com.example.clubhouse.ui.delegates
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Build
+import com.example.clubhouse.R
+import com.example.clubhouse.data.ContactEntity
+import com.example.clubhouse.data.isLeap
+import com.example.clubhouse.ui.fragments.CONTACT_ARG_ID
+import com.example.clubhouse.ui.receivers.ContactBirthdayReceiver
+import com.example.clubhouse.ui.services.RebootReminderService
+import java.util.*
+
+const val CONTACT_SHARED_PREFERENCES_KEY = "contact_shared_prefs"
+const val CONTACT_IDS_ARRAY_KEY = "contact_ids_array"
+
+object ReminderDelegate {
+    private var alarmManager: AlarmManager? = null
+    private var alarmIntent: PendingIntent? = null
+    private var intent: Intent? = null
+    private var sharedPreferences: SharedPreferences? = null
+
+    fun setReminder(context: Context, contact: ContactEntity) {
+        checkAlarmManager(context)
+
+        if (!isReminderSet(context, contact)) {
+            alarmIntent = PendingIntent.getBroadcast(
+                context,
+                contact.id,
+                intent,
+                0
+            )
+        }
+
+        writeContactId(contact.id)
+        scheduleAlarm(contact)
+    }
+
+    fun clearReminder(context: Context, contactId: Int) {
+        checkAlarmManager(context)
+        checkSharedPreferences(context)
+
+        alarmManager?.cancel(alarmIntent)
+        alarmIntent?.cancel()
+        alarmIntent = null
+
+        sharedPreferences
+            ?.edit()
+            ?.remove(contactId.toString())
+            ?.apply()
+    }
+
+    fun isReminderSet(context: Context, contact: ContactEntity): Boolean {
+        checkIntent(context, contact)
+
+        alarmIntent = PendingIntent.getBroadcast(
+            context,
+            contact.id,
+            intent,
+            PendingIntent.FLAG_NO_CREATE
+        )
+
+        return alarmIntent != null
+    }
+
+    fun resetAllContacts(context: Context) {
+        checkSharedPreferences(context)
+
+        sharedPreferences?.all?.run {
+            Intent(
+                context,
+                RebootReminderService::class.java
+            ).apply {
+                putExtra(
+                    CONTACT_IDS_ARRAY_KEY,
+                    keys.filterNotNull().map {
+                        it.toInt()
+                    }.toIntArray()
+                )
+            }.let {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(it)
+                } else {
+                    context.startService(it)
+                }
+            }
+        }
+    }
+
+    private fun writeContactId(contactId: Int) {
+        sharedPreferences
+            ?.edit()
+            ?.putBoolean(contactId.toString(), true)
+            ?.apply()
+    }
+
+    private fun checkSharedPreferences(context: Context) {
+        if (sharedPreferences == null) {
+            sharedPreferences = context.getSharedPreferences(
+                CONTACT_SHARED_PREFERENCES_KEY,
+                Context.MODE_PRIVATE
+            )
+        }
+    }
+
+    private fun scheduleAlarm(contact: ContactEntity) {
+        Calendar.getInstance().run {
+            val previous = timeInMillis
+
+            set(Calendar.MONTH, contact.birthDate.month)
+            set(Calendar.DAY_OF_MONTH, contact.birthDate.day)
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+
+            if (timeInMillis <= previous) {
+                set(Calendar.YEAR, get(Calendar.YEAR) + 1)
+            }
+
+            if (contact.birthDate.isLeap()) {
+                while (!isLeap()) {
+                    set(Calendar.YEAR, (get(Calendar.YEAR) / 4 + 1) * 4)
+                }
+            }
+
+            alarmManager?.set(
+                AlarmManager.RTC,
+                timeInMillis,
+                alarmIntent
+            )
+        }
+    }
+
+    private fun createAlarmIntent(
+        context: Context,
+        contact: ContactEntity
+    ) = Intent(
+        context,
+        ContactBirthdayReceiver::class.java
+    ).apply {
+        action = context.getString(R.string.birthday_action)
+        putExtra(CONTACT_ARG_ID, contact.id)
+    }
+
+    private fun checkAlarmManager(context: Context) {
+        if (alarmManager == null) {
+            alarmManager = context.getSystemService(Context.ALARM_SERVICE)
+                    as? AlarmManager
+        }
+    }
+
+    private fun checkIntent(context: Context, contact: ContactEntity) {
+        if (intent == null) {
+            intent = createAlarmIntent(context, contact)
+        }
+    }
+}

--- a/app/src/main/java/com/example/clubhouse/ui/fragments/ContactListFragment.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/fragments/ContactListFragment.kt
@@ -14,8 +14,6 @@ import kotlinx.coroutines.launch
 
 const val CONTACT_LIST_FRAGMENT_TAG = "fragment_contact_list"
 
-private const val ENTITY_KEY = "simple_contact_entity"
-
 class ContactListFragment :
     ContactServiceFragment(R.layout.fragment_contact_list),
     ContactServiceConsumer {
@@ -45,13 +43,13 @@ class ContactListFragment :
             }
         }
 
-        savedInstanceState?.getParcelable<SimpleContactEntity>(ENTITY_KEY)?.let {
+        savedInstanceState?.getParcelable<SimpleContactEntity>(CONTACT_ENTITY_KEY)?.let {
             updateContact(it)
         } ?: updateUI()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(ENTITY_KEY, contact)
+        outState.putParcelable(CONTACT_ENTITY_KEY, contact)
 
         super.onSaveInstanceState(outState)
     }

--- a/app/src/main/java/com/example/clubhouse/ui/interfaces/ContactEntityOwner.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/interfaces/ContactEntityOwner.kt
@@ -1,0 +1,7 @@
+package com.example.clubhouse.ui.interfaces
+
+import com.example.clubhouse.data.ContactEntity
+
+interface ContactEntityOwner {
+    fun getContact(): ContactEntity?
+}

--- a/app/src/main/java/com/example/clubhouse/ui/receivers/ContactBirthdayReceiver.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/receivers/ContactBirthdayReceiver.kt
@@ -1,0 +1,41 @@
+package com.example.clubhouse.ui.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.example.clubhouse.R
+import com.example.clubhouse.ui.activities.CONTACT_ARG_NULL_VALUE
+import com.example.clubhouse.ui.delegates.ReminderDelegate
+import com.example.clubhouse.ui.fragments.CONTACT_ARG_ID
+import com.example.clubhouse.ui.services.BirthdayNotificationService
+
+class ContactBirthdayReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            context.getString(R.string.birthday_action) -> {
+                intent.getIntExtra(
+                    CONTACT_ARG_ID,
+                    CONTACT_ARG_NULL_VALUE
+                ).let { id ->
+                    if (id != CONTACT_ARG_NULL_VALUE) {
+                        Intent(
+                            context, BirthdayNotificationService::class.java
+                        ).apply {
+                            putExtra(CONTACT_ARG_ID, id)
+                        }.let {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                context.startForegroundService(it)
+                            } else {
+                                context.startService(it)
+                            }
+                        }
+                    }
+                }
+            }
+            Intent.ACTION_BOOT_COMPLETED -> {
+                ReminderDelegate.resetAllContacts(context)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/clubhouse/ui/services/BirthdayNotificationService.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/services/BirthdayNotificationService.kt
@@ -1,0 +1,137 @@
+package com.example.clubhouse.ui.services
+
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.example.clubhouse.R
+import com.example.clubhouse.data.ContactEntity
+import com.example.clubhouse.data.MockDataSource
+import com.example.clubhouse.ui.activities.CONTACT_ARG_NULL_VALUE
+import com.example.clubhouse.ui.activities.MainActivity
+import com.example.clubhouse.ui.delegates.ReminderDelegate
+import com.example.clubhouse.ui.fragments.CONTACT_ARG_ID
+import kotlinx.coroutines.*
+import timber.log.Timber
+import kotlin.coroutines.CoroutineContext
+
+private const val FOREGROUND_NOTIFICATION_ID = -0b1011010
+
+class BirthdayNotificationService : Service(), CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.IO + job
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            initializeForeground()
+        }
+
+        intent?.getIntExtra(
+            CONTACT_ARG_ID,
+            CONTACT_ARG_NULL_VALUE
+        )?.let { id ->
+            if (id != CONTACT_ARG_NULL_VALUE) {
+                launch {
+                    try {
+                        delay(2000)
+
+                        val contact = MockDataSource.getContact(id)
+
+                        showBirthdayNotification(contact)
+                        ReminderDelegate.setReminder(
+                            this@BirthdayNotificationService,
+                            contact
+                        )
+                    } catch (e: CancellationException) {
+                        Timber.d("Service job cancelled\n$e")
+                    } finally {
+                        stopForeground(true)
+                        stopSelf()
+                    }
+                }
+
+                return START_NOT_STICKY
+            }
+        }
+
+        stopForeground(true)
+        stopSelf()
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        job.cancel()
+
+        super.onDestroy()
+    }
+
+    private fun initializeForeground() {
+        startForeground(
+            FOREGROUND_NOTIFICATION_ID,
+            NotificationCompat.Builder(
+                this,
+                getString(R.string.birthday_channel_id)
+            )
+                .setContentTitle(
+                    getString(
+                        R.string.happy_birthday
+                    )
+                )
+                .setContentText(
+                    getString(
+                        R.string.getting_data_about_birthday_kid
+                    )
+                )
+                .setSmallIcon(
+                    R.drawable.ic_baseline_person_24
+                )
+                .build()
+        )
+    }
+
+    private fun showBirthdayNotification(contact: ContactEntity) {
+        NotificationManagerCompat.from(this).notify(
+            contact.id,
+            NotificationCompat
+                .Builder(
+                    this,
+                    getString(
+                        R.string.birthday_channel_id
+                    )
+                )
+                .setSmallIcon(R.drawable.ic_baseline_person_24)
+                .setContentTitle(
+                    getString(
+                        R.string.someone_has_birthday_today_fmt,
+                        contact.name
+                    )
+                )
+                .setContentText(getString(R.string.birthday_content_text))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setContentIntent(
+                    PendingIntent.getActivity(
+                        this,
+                        contact.id,
+                        Intent(this, MainActivity::class.java).apply {
+                            putExtra(CONTACT_ARG_ID, contact.id)
+
+                            action = getString(
+                                R.string.birthday_notification_action
+                            )
+                            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or
+                                    Intent.FLAG_ACTIVITY_NEW_TASK
+                        },
+                        0
+                    )
+                )
+                .setAutoCancel(true)
+                .build()
+        )
+    }
+}

--- a/app/src/main/java/com/example/clubhouse/ui/services/ContactService.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/services/ContactService.kt
@@ -15,13 +15,13 @@ class ContactService : Service() {
     }
 
     suspend fun getContacts() = withContext(Dispatchers.IO) {
-        delay(3000)
+        delay(500)
 
-        MockDataSource.getContacts()
+        MockDataSource.getSimpleContacts()
     }
 
     suspend fun getContact(id: Int) = withContext(Dispatchers.IO) {
-        delay(3000)
+        delay(500)
 
         MockDataSource.getContact(id)
     }

--- a/app/src/main/java/com/example/clubhouse/ui/services/RebootReminderService.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/services/RebootReminderService.kt
@@ -1,0 +1,86 @@
+package com.example.clubhouse.ui.services
+
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.example.clubhouse.R
+import com.example.clubhouse.data.MockDataSource
+import com.example.clubhouse.ui.delegates.CONTACT_IDS_ARRAY_KEY
+import com.example.clubhouse.ui.delegates.ReminderDelegate
+import kotlinx.coroutines.*
+import timber.log.Timber
+import kotlin.coroutines.CoroutineContext
+
+private const val FOREGROUND_NOTIFICATION_ID = -0b10010101
+
+class RebootReminderService : Service(), CoroutineScope {
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.IO + job
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            initializeForeground()
+        }
+
+        intent?.getIntArrayExtra(CONTACT_IDS_ARRAY_KEY)?.let { ids ->
+            launch {
+                try {
+                    delay(10000)
+
+                    MockDataSource.getContacts(ids).forEach {
+                        ReminderDelegate.setReminder(
+                            this@RebootReminderService,
+                            it
+                        )
+                    }
+                } catch (e: CancellationException) {
+                    Timber.d("Service job cancelled\n$e")
+                } finally {
+                    stopForeground(true)
+                    stopSelf()
+                }
+            }
+
+            return START_NOT_STICKY
+        }
+
+        stopForeground(true)
+        stopSelf()
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        job.cancel()
+
+        super.onDestroy()
+    }
+
+    private fun initializeForeground() {
+        startForeground(
+            FOREGROUND_NOTIFICATION_ID,
+            NotificationCompat.Builder(
+                this,
+                getString(R.string.birthday_channel_id)
+            )
+                .setContentTitle(
+                    getString(
+                        R.string.birthday_presents
+                    )
+                )
+                .setContentText(
+                    getString(
+                        R.string.getting_data_about_birthday_kids
+                    )
+                )
+                .setSmallIcon(
+                    R.drawable.ic_baseline_person_24
+                )
+                .build()
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_contact_details.xml
+++ b/app/src/main/res/layout/fragment_contact_details.xml
@@ -54,11 +54,36 @@
         app:layout_constraintTop_toBottomOf="@id/contactDetailsEmail1" />
 
     <TextView
+        android:id="@+id/contactDetailsBirthDate"
+        style="@style/ContactDetailsListItem"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/contactDetailsEmail2" />
+
+    <TextView
         android:id="@+id/contactDetailsDescription"
         android:layout_width="0dp"
         android:layout_height="@dimen/cardImageViewSide"
         android:gravity="center_vertical|start"
         android:text="@string/description"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/contactDetailsEmail2" />
+        app:layout_constraintTop_toBottomOf="@id/contactDetailsBirthDate" />
+
+    <TextView
+        android:id="@+id/contactDetailsRemindTextView"
+        style="@style/ContactDetailsListItem"
+        android:layout_marginTop="@dimen/cardListPadding"
+        android:text="@string/remind_about_birthday"
+        android:visibility="gone"
+        app:layout_constraintEnd_toStartOf="@id/contactDetailsRemindSwitch"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/contactDetailsDescription" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/contactDetailsRemindSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/contactDetailsRemindTextView"
+        app:layout_constraintTop_toBottomOf="@id/contactDetailsDescription" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -10,4 +10,16 @@
     <string name="contact_list">Список контактов</string>
     <string name="contact_details">Детали контакта</string>
     <string name="no_phone_number">Нет телефона</string>
+    <string name="birthday_fmt">День рождения: %s</string>
+    <string name="remind">Напоминать</string>
+    <string name="dont_remind">Не напоминать</string>
+    <string name="remind_about_birthday">Напоминать о дне рождения?</string>
+    <string name="someone_has_birthday_today_fmt">%s празднует день рождения!</string>
+    <string name="birthday_content_text">Пожелайте счастливого времяпровождения!</string>
+    <string name="birthday_channel_name">Канал уведомлений о днях рождения</string>
+    <string name="birthday_channel_description">К сожаленью, день рожденья…</string>
+    <string name="getting_data_about_birthday_kid">Получаю данные об имениннике…</string>
+    <string name="happy_birthday">С днём рождения!</string>
+    <string name="getting_data_about_birthday_kids">Получаю данные об именинниках…</string>
+    <string name="birthday_presents">Подарки на день рождения!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,11 @@
 <resources>
     <string name="app_name" translatable="false">Clubhouse</string>
+    <string name="birthday_action" translatable="false">clubhouse_birthday_action</string>
+    <string name="birthday_notification_action" translatable="false">
+        clubhouse_notification_birthday_action
+    </string>
+    <string name="birthday_channel_id" translatable="false">clubhouse_notification</string>
+
     <string name="photo">Photo</string>
     <string name="name">Name</string>
     <string name="phone">Phone</string>
@@ -10,4 +16,16 @@
     <string name="contact_list">Contact list</string>
     <string name="contact_details">Contact details</string>
     <string name="no_phone_number">No phone number</string>
+    <string name="birthday_fmt">Birthday: %s</string>
+    <string name="remind_about_birthday">Remind you about birthday?</string>
+    <string name="remind">Remind</string>
+    <string name="dont_remind">Don\'t remind</string>
+    <string name="someone_has_birthday_today_fmt">%s has birthday today!</string>
+    <string name="birthday_content_text">What about saying \'Hey\'?</string>
+    <string name="birthday_channel_name">Birthday notification channel</string>
+    <string name="birthday_channel_description">Welp, its name speaks for itself</string>
+    <string name="happy_birthday">Happy birthday!</string>
+    <string name="birthday_presents">Birthday presents!</string>
+    <string name="getting_data_about_birthday_kid">Getting data about birthday kid…</string>
+    <string name="getting_data_about_birthday_kids">Getting data about birthday kids…</string>
 </resources>


### PR DESCRIPTION
Добавлен `ContactBirthdayReceiver`, получающий оповещения от `AlarmManager` о дне рождении контакта. В связи с этим также создан `data class BirthDate`, содержащий число и месяц появления контакта на свет.

Активность создаёт пока что единственный канал оповещений, на который приходят все уведомления о днях рождения. Когда пользователь нажимает на уведомление, `MainActivity` получает `Intent`, содержащий `id` контакта, указанного в оповещении, а затем создаёт `ContactDetailsFragment`, передавая соответствующий `id`. В этом же фрагменте пользователь может подписаться на рассылку или отписаться от неё. Проверка уже существующей подписи осуществляется с помощью `PendingIntent.FLAG_NO_CREATE`.