### PR TITLE
Рефакторинг приложения с использованием RxJava

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
 
+    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
+    implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
     implementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.3.1'

--- a/app/src/main/java/com/example/clubhouse/data/ContactEntity.kt
+++ b/app/src/main/java/com/example/clubhouse/data/ContactEntity.kt
@@ -7,10 +7,10 @@ import kotlinx.parcelize.Parcelize
 data class ContactEntity(
     val id: Long,
     val lookup: String,
-    val name: String?,
-    val phoneNumbers: List<String>,
-    val emails: List<String>,
+    val name: String? = null,
     val description: String? = null,
     val birthDate: BirthDate? = null,
-    val photoId: Long? = null
+    val photoId: Long? = null,
+    val emails: List<String> = listOf(),
+    val phoneNumbers: List<String> = listOf()
 ) : Parcelable

--- a/app/src/main/java/com/example/clubhouse/data/ContactRepository.kt
+++ b/app/src/main/java/com/example/clubhouse/data/ContactRepository.kt
@@ -1,12 +1,12 @@
 package com.example.clubhouse.data
 
+import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
 import android.provider.ContactsContract
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import androidx.core.database.getLongOrNull
+import androidx.core.database.getStringOrNull
+import io.reactivex.rxjava3.core.Single
 
 private const val SELECTION = "${ContactsContract.Data.LOOKUP_KEY} = ?"
 private val CONTACT_PROJECTION = arrayOf(
@@ -30,18 +30,22 @@ private const val SIMPLE_DATA_SELECTION =
         ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE
     }') and ${
         ContactsContract.Data.LOOKUP_KEY
-    } = ?"
+    } in "
 private val DATA_PROJECTION = arrayOf(
     ContactsContract.Data.MIMETYPE,
+    ContactsContract.Data.LOOKUP_KEY,
     ContactsContract.Data.DATA1,
     ContactsContract.Data.DATA2,
     ContactsContract.CommonDataKinds.Photo.PHOTO_FILE_ID
 )
 private const val DATA_SORT_ORDER = "${ContactsContract.Data.MIMETYPE} asc"
 private const val DATA_MIMETYPE_INDEX = 0
-private const val DATA_FIELD_INDEX = 1
-private const val DATA_ADDITIONAL_FIELD_INDEX = 2
-private const val DATA_PHOTO_ID_INDEX = 3
+private const val DATA_LOOKUP_INDEX = 1
+private const val DATA_FIELD_INDEX = 2
+private const val DATA_ADDITIONAL_FIELD_INDEX = 3
+private const val DATA_PHOTO_ID_INDEX = 4
+
+private const val CONTACT_NO_ID = -1L
 
 object ContactRepository {
     fun makePhotoUri(photoId: Long) =
@@ -50,60 +54,40 @@ object ContactRepository {
             photoId
         )
 
-    suspend fun getSimpleContacts(
+    fun getSimpleContacts(
         context: Context,
         query: String?
-    ): List<SimpleContactEntity>? = withContext(Dispatchers.IO) {
-        context.contentResolver?.let { contentResolver ->
-            val contacts = mutableListOf<SimpleContactEntity>()
-            val selection: String?
-            val selectionArgs: Array<String>?
-
-            if (query == null || query.isBlank()) {
-                selection = null
-                selectionArgs = null
-            } else {
-                selection = SIMPLE_CONTACT_SELECTION
-                selectionArgs = arrayOf("%${query}%")
-            }
-
-            contentResolver.query(
-                ContactsContract.Contacts.CONTENT_URI,
-                CONTACT_PROJECTION,
-                selection,
-                selectionArgs,
-                CONTACT_SORT_ORDER
-            )?.use {
-                if (it.moveToFirst()) {
-                    do {
-                        contacts.add(
-                            SimpleContactEntity(
-                                it.getLong(CONTACT_ID_INDEX),
-                                it.getString(CONTACT_LOOKUP_INDEX),
-                                it.getString(CONTACT_NAME_INDEX)
-                            )
-                        )
-                    } while (it.moveToNext())
+    ): Single<List<SimpleContactEntity>> {
+        return Single.fromCallable {
+            context.contentResolver?.let { resolver ->
+                val contacts = getContactListFramework(query, resolver)
+                val lookupToIndex = contacts.withIndex().associate {
+                    it.value.lookup to it.index
                 }
-            }
+                val selection = SIMPLE_DATA_SELECTION +
+                        lookupToIndex.keys.joinToString(
+                            prefix = "(",
+                            postfix = ")"
+                        ) { "?" }
 
-            List(contacts.size) { i ->
-                launch {
-                    contentResolver.query(
-                        ContactsContract.Data.CONTENT_URI,
-                        DATA_PROJECTION,
-                        SIMPLE_DATA_SELECTION,
-                        arrayOf(contacts[i].lookup),
-                        DATA_SORT_ORDER
-                    )?.use { it ->
-                        if (it.moveToFirst()) {
-                            do {
-                                when (it.getString(DATA_MIMETYPE_INDEX)) {
+                resolver.query(
+                    ContactsContract.Data.CONTENT_URI,
+                    DATA_PROJECTION,
+                    selection,
+                    lookupToIndex.keys.toTypedArray(),
+                    DATA_SORT_ORDER
+                )?.use {
+                    if (it.moveToFirst()) {
+                        do {
+                            it.getStringOrNull(DATA_LOOKUP_INDEX)?.let { key ->
+                                lookupToIndex[key]
+                            }?.let(fun(i: Int) {
+                                when (it.getStringOrNull(DATA_MIMETYPE_INDEX)) {
                                     ContactsContract
                                         .CommonDataKinds
                                         .Phone
                                         .CONTENT_ITEM_TYPE -> {
-                                        it.getString(
+                                        it.getStringOrNull(
                                             DATA_FIELD_INDEX
                                         )?.let { phone ->
                                             contacts[i].phoneNumber = phone
@@ -114,52 +98,46 @@ object ContactRepository {
                                         .CommonDataKinds
                                         .Photo
                                         .CONTENT_ITEM_TYPE -> {
-                                        it.getLong(
+                                        it.getLongOrNull(
                                             DATA_PHOTO_ID_INDEX
-                                        ).let { rowPhotoId ->
+                                        )?.let { rowPhotoId ->
                                             if (rowPhotoId > 0) {
                                                 contacts[i].photoId = rowPhotoId
                                             }
                                         }
                                     }
                                 }
-                            } while (it.moveToNext())
-                        }
+                            })
+                        } while (it.moveToNext())
                     }
                 }
-            }.joinAll()
 
-            contacts
+                contacts
+            } ?: throw makeContentResolverError()
         }
     }
 
-    suspend fun getContacts(
+    fun getContacts(
         context: Context,
         lookups: List<String?>
-    ): List<ContactEntity> = withContext(Dispatchers.IO) {
-        val contacts: MutableList<ContactEntity?> =
-            MutableList(lookups.size) { null }
-
-        List(lookups.size) { i ->
-            launch {
-                contacts[i] = lookups[i]?.let {
-                    getContact(
-                        context,
-                        it
-                    )
-                }
+    ): Single<List<ContactEntity>> {
+        return Single.merge(
+            lookups.filterNotNull().map { lookup ->
+                getContact(
+                    context,
+                    lookup
+                )
             }
-        }.joinAll()
-
-        contacts.filterNotNull()
+        )
+            .toList()
     }
 
-    suspend fun getContact(
+    fun getContact(
         context: Context,
         lookup: String
-    ) = withContext(Dispatchers.IO) {
-        context.contentResolver?.let { contentResolver ->
-            var id: Long = 0
+    ): Single<ContactEntity> {
+        return Single.fromCallable {
+            var id = CONTACT_NO_ID
             var name: String? = null
             var description: String? = null
             var birthDate: BirthDate? = null
@@ -167,123 +145,164 @@ object ContactRepository {
             val emails = mutableListOf<String>()
             val phones = mutableListOf<String>()
 
-            listOf(
-                launch {
-                    contentResolver.query(
-                        ContactsContract.Contacts.CONTENT_URI,
-                        CONTACT_PROJECTION,
-                        SELECTION,
-                        arrayOf(lookup),
-                        CONTACT_SORT_ORDER
-                    )?.use {
-                        if (it.moveToFirst()) {
-                            id = it.getLong(CONTACT_ID_INDEX)
-                        }
-                    }
-                },
-                launch {
-                    contentResolver.query(
-                        ContactsContract.Data.CONTENT_URI,
-                        DATA_PROJECTION,
-                        SELECTION,
-                        arrayOf(lookup),
-                        null
-                    )?.use {
-                        if (it.moveToFirst()) {
-                            do {
-                                when (it.getString(DATA_MIMETYPE_INDEX)) {
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .StructuredName
-                                        .CONTENT_ITEM_TYPE -> {
-                                        name = it.getString(
-                                            DATA_FIELD_INDEX
-                                        )
-                                    }
-
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Email
-                                        .CONTENT_ITEM_TYPE -> {
-                                        it.getString(
-                                            DATA_FIELD_INDEX
-                                        )?.let { email ->
-                                            emails.add(email)
-                                        }
-                                    }
-
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Phone
-                                        .CONTENT_ITEM_TYPE -> {
-                                        it.getString(
-                                            DATA_FIELD_INDEX
-                                        )?.let { phone ->
-                                            phones.add(phone)
-                                        }
-                                    }
-
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Note
-                                        .CONTENT_ITEM_TYPE -> {
-                                        description =
-                                            it.getString(DATA_FIELD_INDEX)
-                                    }
-
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Event
-                                        .CONTENT_ITEM_TYPE -> {
-                                        if (it.getInt(
-                                                DATA_ADDITIONAL_FIELD_INDEX
-                                            ) == ContactsContract
-                                                .CommonDataKinds
-                                                .Event
-                                                .TYPE_BIRTHDAY
-                                        ) {
-                                            it.getString(DATA_FIELD_INDEX)
-                                                ?.split("-")
-                                                ?.reversed()
-                                                ?.let { date ->
-                                                    birthDate = BirthDate(
-                                                        date[0].toInt(),
-                                                        date[1].toInt() - 1
-                                                    )
-                                                }
-                                        }
-                                    }
-
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Photo
-                                        .CONTENT_ITEM_TYPE -> {
-                                        it.getLong(
-                                            DATA_PHOTO_ID_INDEX
-                                        ).let { rowPhotoId ->
-                                            if (rowPhotoId > 0) {
-                                                photoId = rowPhotoId
-                                            }
-                                        }
-
-                                    }
-                                }
-                            } while (it.moveToNext())
+            context.contentResolver?.let { contentResolver ->
+                contentResolver.query(
+                    ContactsContract.Contacts.CONTENT_URI,
+                    CONTACT_PROJECTION,
+                    SELECTION,
+                    arrayOf(lookup),
+                    CONTACT_SORT_ORDER
+                )?.use {
+                    if (it.moveToFirst()) {
+                        it.getLongOrNull(CONTACT_ID_INDEX)?.let { newId ->
+                            id = newId
                         }
                     }
                 }
-            ).joinAll()
 
-            ContactEntity(
-                id,
-                lookup,
-                name,
-                phones,
-                emails,
-                description,
-                birthDate,
-                photoId
-            )
+                contentResolver.query(
+                    ContactsContract.Data.CONTENT_URI,
+                    DATA_PROJECTION,
+                    SELECTION,
+                    arrayOf(lookup),
+                    null
+                )?.use {
+                    if (it.moveToFirst()) {
+                        do {
+                            when (it.getString(DATA_MIMETYPE_INDEX)) {
+                                ContactsContract
+                                    .CommonDataKinds
+                                    .StructuredName
+                                    .CONTENT_ITEM_TYPE -> {
+                                    name = it.getString(
+                                        DATA_FIELD_INDEX
+                                    )
+                                }
+
+                                ContactsContract
+                                    .CommonDataKinds
+                                    .Email
+                                    .CONTENT_ITEM_TYPE -> {
+                                    it.getString(
+                                        DATA_FIELD_INDEX
+                                    )?.let { email ->
+                                        emails.add(email)
+                                    }
+                                }
+
+                                ContactsContract
+                                    .CommonDataKinds
+                                    .Phone
+                                    .CONTENT_ITEM_TYPE -> {
+                                    it.getString(
+                                        DATA_FIELD_INDEX
+                                    )?.let { phone ->
+                                        phones.add(phone)
+                                    }
+                                }
+
+                                ContactsContract
+                                    .CommonDataKinds
+                                    .Note
+                                    .CONTENT_ITEM_TYPE -> {
+                                    description = it.getString(DATA_FIELD_INDEX)
+                                }
+
+                                ContactsContract
+                                    .CommonDataKinds
+                                    .Event
+                                    .CONTENT_ITEM_TYPE -> {
+                                    if (it.getInt(
+                                            DATA_ADDITIONAL_FIELD_INDEX
+                                        ) == ContactsContract
+                                            .CommonDataKinds
+                                            .Event
+                                            .TYPE_BIRTHDAY
+                                    ) {
+                                        it.getString(DATA_FIELD_INDEX)
+                                            ?.split("-")
+                                            ?.reversed()
+                                            ?.let { date ->
+                                                birthDate = BirthDate(
+                                                    date[0].toInt(),
+                                                    date[1].toInt() - 1
+                                                )
+                                            }
+                                    }
+                                }
+
+                                ContactsContract
+                                    .CommonDataKinds
+                                    .Photo
+                                    .CONTENT_ITEM_TYPE -> {
+                                    it.getLong(
+                                        DATA_PHOTO_ID_INDEX
+                                    ).let { rowPhotoId ->
+                                        if (rowPhotoId > 0) {
+                                            photoId = rowPhotoId
+                                        }
+                                    }
+
+                                }
+                            }
+                        } while (it.moveToNext())
+                    }
+                }
+
+                if (id == CONTACT_NO_ID) {
+                    throw IllegalStateException("Contact id can't be null.")
+                }
+
+                ContactEntity(
+                    id,
+                    lookup,
+                    name,
+                    description,
+                    birthDate,
+                    photoId,
+                    emails,
+                    phones
+                )
+            } ?: throw makeContentResolverError()
         }
+    }
+
+    private fun makeContentResolverError() = IllegalStateException(
+        "ContentResolver was found out to be null :("
+    )
+
+    private fun getContactListFramework(
+        query: String?,
+        contentResolver: ContentResolver
+    ): List<SimpleContactEntity> {
+        val contactList = mutableListOf<SimpleContactEntity>()
+
+        val (selection, selectionArgs) = if (query == null || query.isBlank()) {
+            null to null
+        } else {
+            SIMPLE_CONTACT_SELECTION to arrayOf("%${query}%")
+        }
+
+        contentResolver.query(
+            ContactsContract.Contacts.CONTENT_URI,
+            CONTACT_PROJECTION,
+            selection,
+            selectionArgs,
+            CONTACT_SORT_ORDER
+        )?.use {
+            if (it.moveToFirst()) {
+                do {
+                    contactList.add(
+                        SimpleContactEntity(
+                            it.getLong(CONTACT_ID_INDEX),
+                            it.getString(CONTACT_LOOKUP_INDEX),
+                            it.getString(CONTACT_NAME_INDEX)
+                        )
+                    )
+                } while (it.moveToNext())
+            }
+        }
+
+        return contactList
     }
 }

--- a/app/src/main/java/com/example/clubhouse/ui/adapters/ContactAdapter.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/adapters/ContactAdapter.kt
@@ -4,8 +4,10 @@ import androidx.recyclerview.widget.DiffUtil
 import com.example.clubhouse.data.SimpleContactEntity
 import com.example.clubhouse.ui.adapters.items.ContactListItem
 import com.example.clubhouse.ui.delegates.contactEntityDelegate
+import com.example.clubhouse.ui.delegates.contactErrorDelegate
 import com.example.clubhouse.ui.delegates.contactFooterDelegate
 import com.example.clubhouse.ui.delegates.contactHeaderDelegate
+import com.example.clubhouse.ui.delegates.contactProgressDelegate
 import com.hannesdorfmann.adapterdelegates4.AsyncListDifferDelegationAdapter
 
 object ContactDiffCallback : DiffUtil.ItemCallback<ContactListItem>() {
@@ -44,6 +46,8 @@ class ContactAdapter(
 ) : AsyncListDifferDelegationAdapter<ContactListItem>(ContactDiffCallback) {
     init {
         delegatesManager.addDelegate(contactHeaderDelegate())
+        delegatesManager.addDelegate(contactProgressDelegate())
+        delegatesManager.addDelegate(contactErrorDelegate())
         delegatesManager.addDelegate(contactEntityDelegate { position ->
             (items[position] as? ContactListItem.Entity)
                 ?.let { item ->

--- a/app/src/main/java/com/example/clubhouse/ui/adapters/items/ContactListItem.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/adapters/items/ContactListItem.kt
@@ -4,6 +4,8 @@ import com.example.clubhouse.data.SimpleContactEntity
 
 sealed class ContactListItem {
     object Header : ContactListItem()
+    object Progress : ContactListItem()
+    object Error : ContactListItem()
     data class Entity(val contact: SimpleContactEntity) : ContactListItem()
     data class Footer(val count: Int) : ContactListItem()
 }

--- a/app/src/main/java/com/example/clubhouse/ui/delegates/ContactAdapterDelegates.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/delegates/ContactAdapterDelegates.kt
@@ -14,6 +14,16 @@ fun contactHeaderDelegate() =
         R.layout.contact_list_header
     ) {}
 
+fun contactProgressDelegate() =
+    adapterDelegate<ContactListItem.Progress, ContactListItem>(
+        R.layout.progress_card
+    ) {}
+
+fun contactErrorDelegate() =
+    adapterDelegate<ContactListItem.Error, ContactListItem>(
+        R.layout.error_card
+    ) {}
+
 fun contactEntityDelegate(
     clickListener: (Int) -> Unit
 ) = adapterDelegate<ContactListItem.Entity, ContactListItem>(

--- a/app/src/main/java/com/example/clubhouse/ui/fragments/ContactDetailsFragment.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/fragments/ContactDetailsFragment.kt
@@ -6,6 +6,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.children
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.example.clubhouse.R
@@ -93,18 +94,28 @@ class ContactDetailsFragment :
         this.contactEntity = contact
 
         binding?.run {
+            if (!contactDetailsRefreshView.isEnabled) {
+                contactDetailsRefreshView.isEnabled = true
+                contactDetailsContents.removeView(
+                    contactDetailsProgressGroup
+                )
+            }
+
             contact.photoId?.let {
                 contactDetailsPhoto.run {
                     setImageURI(ContactRepository.makePhotoUri(it))
-
+                    visibility = View.VISIBLE
                     imageTintList = null
                 }
             }
 
             contactDetailsName.text =
                 contact.name ?: getString(R.string.no_name)
+            contactDetailsName.visibility = View.VISIBLE
+
             contactDetailsDescription.text =
                 contact.description ?: getString(R.string.no_description)
+            contactDetailsDescription.visibility = View.VISIBLE
 
             val phonesIterator = contact.phoneNumbers.listIterator()
             val emailsIterator = contact.emails.listIterator()
@@ -115,8 +126,7 @@ class ContactDetailsFragment :
             ).forEach {
                 if (phonesIterator.hasNext()) {
                     it.text = phonesIterator.next()
-                } else {
-                    it.visibility = View.GONE
+                    it.visibility = View.VISIBLE
                 }
             }
 
@@ -126,12 +136,12 @@ class ContactDetailsFragment :
             ).forEach {
                 if (emailsIterator.hasNext()) {
                     it.text = emailsIterator.next()
-                } else {
-                    it.visibility = View.GONE
+                    it.visibility = View.VISIBLE
                 }
             }
 
             contact.birthDate?.run {
+                contactDetailsBirthDate.visibility = View.VISIBLE
                 contactDetailsRemindTextView.visibility = View.VISIBLE
 
                 contactDetailsRemindSwitch.run {
@@ -148,7 +158,8 @@ class ContactDetailsFragment :
                     DateUtils.formatDateTime(
                         requireContext(),
                         timeInMillis,
-                        DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_NO_YEAR
+                        DateUtils.FORMAT_SHOW_DATE or
+                                DateUtils.FORMAT_NO_YEAR
                     )
                 )
             }
@@ -156,6 +167,13 @@ class ContactDetailsFragment :
     }
 
     private fun updateUI() {
+        viewModel.throwable.observe(viewLifecycleOwner) {
+            binding?.contactDetailsContents?.children?.forEach {
+                it.visibility = View.GONE
+            }
+            binding?.contactDetailsErrorGroup?.visibility = View.VISIBLE
+        }
+
         viewModel.contact.observe(viewLifecycleOwner) { contact ->
             updateContact(contact)
 
@@ -178,11 +196,14 @@ class ContactDetailsFragment :
     }
 
     private fun initializeRefreshView() {
-        binding?.contactDetailsRefreshView?.setColorSchemeResources(
-            R.color.colorPrimary
-        )
-        binding?.contactDetailsRefreshView?.setOnRefreshListener {
-            refreshContactDetails()
+        binding?.contactDetailsRefreshView?.run {
+            setColorSchemeResources(
+                R.color.colorPrimary
+            )
+            setOnRefreshListener {
+                refreshContactDetails()
+            }
+            isEnabled = false
         }
     }
 }

--- a/app/src/main/java/com/example/clubhouse/ui/fragments/ContactListFragment.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/fragments/ContactListFragment.kt
@@ -150,6 +150,10 @@ class ContactListFragment :
     }
 
     private fun updateUI() {
+        viewModel.throwable.observe(viewLifecycleOwner) {
+            viewAdapter?.items = listOf(ContactListItem.Error)
+        }
+
         viewModel.contactList.observe(viewLifecycleOwner) {
             updateContactList(it)
 
@@ -158,6 +162,10 @@ class ContactListFragment :
 
         (activity as? ReadContactsPermissionRequester)?.run {
             requestPermission {
+                if (viewModel.contactList.value == null) {
+                    viewAdapter?.items = listOf(ContactListItem.Progress)
+                }
+
                 viewModel.contactList.observe(viewLifecycleOwner) {
                     updateContactList(it)
                 }
@@ -168,6 +176,8 @@ class ContactListFragment :
     }
 
     private fun search(query: String?) {
+        viewAdapter?.items = listOf(ContactListItem.Progress)
+
         viewModel.provideContactList(query)
     }
 

--- a/app/src/main/java/com/example/clubhouse/ui/services/StartedContactService.kt
+++ b/app/src/main/java/com/example/clubhouse/ui/services/StartedContactService.kt
@@ -2,20 +2,19 @@ package com.example.clubhouse.ui.services
 
 import android.Manifest
 import android.app.Service
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.IBinder
 import androidx.core.content.ContextCompat
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlin.coroutines.CoroutineContext
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 
-abstract class StartedContactService : Service(), CoroutineScope {
-    private val job = Job()
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.IO + job
+abstract class StartedContactService : Service() {
+    protected val disposable = CompositeDisposable()
+
+    override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
-        job.cancel()
+        disposable.dispose()
 
         super.onDestroy()
     }

--- a/app/src/main/res/drawable/round_card_background.xml
+++ b/app/src/main/res/drawable/round_card_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="@dimen/cardBorderRadius" />
+    <stroke
+        android:width="@dimen/cardBorderWidth"
+        android:color="@color/colorPrimary" />
+</shape>

--- a/app/src/main/res/layout/error_card.xml
+++ b/app/src/main/res/layout/error_card.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout style="@style/CardGroup">
+
+    <include layout="@layout/error_group" />
+</LinearLayout>

--- a/app/src/main/res/layout/error_group.xml
+++ b/app/src/main/res/layout/error_group.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ImageView
+        android:layout_width="@dimen/cardImageViewSide"
+        android:layout_height="@dimen/cardImageViewSide"
+        android:contentDescription="@string/error"
+        android:src="@drawable/ic_crying_emoji" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/cardVerticalMargin"
+        android:text="@string/error" />
+</merge>

--- a/app/src/main/res/layout/fragment_contact_details.xml
+++ b/app/src/main/res/layout/fragment_contact_details.xml
@@ -1,15 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/contactDetailsRefreshView"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/contactDetailsRefreshView"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/contactDetailsContents"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="@dimen/cardPadding">
+
+        <LinearLayout
+            android:id="@+id/contactDetailsErrorGroup"
+            style="@style/ContactDetailsGroup"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <include layout="@layout/error_group" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/contactDetailsProgressGroup"
+            style="@style/ContactDetailsGroup"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <include layout="@layout/progress_group" />
+        </LinearLayout>
 
         <ImageView
             android:id="@+id/contactDetailsPhoto"
@@ -17,6 +37,7 @@
             android:layout_height="@dimen/cardImageViewSide"
             android:contentDescription="@string/photo"
             android:src="@drawable/ic_baseline_person_24"
+            android:visibility="visible"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:tint="@color/colorPrimary" />
@@ -28,6 +49,7 @@
             android:layout_marginHorizontal="@dimen/cardHorizontalMargin"
             android:gravity="center_vertical"
             android:text="@string/name"
+            android:visibility="visible"
             app:layout_constraintStart_toEndOf="@id/contactDetailsPhoto"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -35,6 +57,7 @@
             android:id="@+id/contactDetailsPhone1"
             style="@style/ContactDetailsListItem"
             android:text="@string/phone"
+            android:visibility="visible"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/contactDetailsPhoto" />
 
@@ -71,6 +94,7 @@
             android:layout_height="@dimen/cardImageViewSide"
             android:gravity="center_vertical"
             android:text="@string/description"
+            android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/contactDetailsBirthDate" />
 

--- a/app/src/main/res/layout/progress_card.xml
+++ b/app/src/main/res/layout/progress_card.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout style="@style/CardGroup">
+
+    <include layout="@layout/progress_group" />
+</LinearLayout>

--- a/app/src/main/res/layout/progress_group.xml
+++ b/app/src/main/res/layout/progress_group.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <ProgressBar
+        android:layout_width="@dimen/cardImageViewSide"
+        android:layout_height="@dimen/cardImageViewSide"
+        android:indeterminate="true" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/cardVerticalMargin"
+        android:text="@string/loading" />
+</merge>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -33,4 +33,6 @@
     <string name="refresh">Обновить</string>
     <string name="hello_world">Привет, Мир!</string>
     <string name="total_contacts">Всего контактов: %d</string>
+    <string name="loading">Загрузка…</string>
+    <string name="error">Произошла ошибка.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,6 @@
     <string name="refresh">Refresh</string>
     <string name="hello_world">Hello, World!</string>
     <string name="total_contacts">Total contacts: %d</string>
+    <string name="loading">Loading…</string>
+    <string name="error">An error occurred.</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -17,5 +17,18 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">@dimen/cardVerticalMargin</item>
+        <item name="android:visibility">gone</item>
+    </style>
+
+    <style name="ContactDetailsGroup">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">center_horizontal</item>
+        <item name="android:orientation">vertical</item>
+        <item name="android:padding">@dimen/cardPadding</item>
+    </style>
+
+    <style name="CardGroup" parent="ContactDetailsGroup">
+        <item name="android:background">@drawable/round_card_background</item>
     </style>
 </resources>


### PR DESCRIPTION
### Репозиторий
`ContactRepository` поменял свои взгляды и решил использовать RxJava (RxKotlin). `getSimpleContacts` использует `Flowable` и `Flowable.parallel` для достижения высокой скорости работы. Сам список контактов объявляется в функции и затем заполняется на первичном этапе для сохранения порядка контактов при использовании `parallel`. 

### `ViewModel`и
Теперь в каждой вьюмодели доступно поле `throwable: LiveData<Throwable>`, которое оповещает подписчиков об ошибке в репозитории. В `onCleared` и перед присваиванием `disposable` нового значения происходит `disposable.dispose()`.

### `RecyclerView` со списком контактов
Появилось 2 новых делегата: один для индикации загрузки, второй - для оповещения об ошибке.