### PR TITLE
Рефакторинг ContactProviderRepository

### DIFF
--- a/presentation/src/main/java/com/example/presentation/data/repositories/ContactProviderRepository.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/ContactProviderRepository.kt
@@ -1,125 +1,50 @@
 package com.example.presentation.data.repositories
 
-import android.content.ContentResolver
 import android.content.Context
-import android.database.Cursor
-import android.provider.ContactsContract
-import androidx.core.database.getIntOrNull
 import androidx.core.database.getLongOrNull
 import androidx.core.database.getStringOrNull
-import com.example.domain.entities.BirthDate
 import com.example.domain.entities.ContactEntity
 import com.example.domain.entities.SimpleContactEntity
 import com.example.domain.repositories.interfaces.ContactRepository
+import com.example.presentation.data.repositories.helpers.ContentResolverHelper
+import com.example.presentation.data.repositories.helpers.populators.ContactPopulationConductor
+import com.example.presentation.data.repositories.helpers.populators.DATA_LOOKUP_INDEX
+import com.example.presentation.data.repositories.helpers.populators.SimpleContactPopulationConductor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-private const val LOOKUP_SELECTION =
-    "${ContactsContract.Contacts.LOOKUP_KEY} = ?"
-private const val ID_SELECTION = "${ContactsContract.Contacts._ID} = ?"
-private val CONTACT_PROJECTION = arrayOf(
-    ContactsContract.Contacts._ID,
-    ContactsContract.Contacts.LOOKUP_KEY,
-    ContactsContract.Contacts.DISPLAY_NAME_PRIMARY
-)
-private const val CONTACT_SORT_ORDER =
-    "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} asc"
 private const val CONTACT_ID_INDEX = 0
 private const val CONTACT_LOOKUP_INDEX = 1
 private const val CONTACT_NAME_INDEX = 2
 
-private const val SIMPLE_CONTACT_SELECTION =
-    "${ContactsContract.Contacts.DISPLAY_NAME} like ?"
-
-private const val SIMPLE_DATA_SELECTION =
-    "${ContactsContract.Data.MIMETYPE} in ('" +
-        ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE +
-        "', '${ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE}" +
-        "') and ${ContactsContract.Data.LOOKUP_KEY} in "
-private val DATA_PROJECTION = arrayOf(
-    ContactsContract.Data.MIMETYPE,
-    ContactsContract.Data.LOOKUP_KEY,
-    ContactsContract.Data.DATA1,
-    ContactsContract.Data.DATA2,
-    ContactsContract.CommonDataKinds.Photo.PHOTO_FILE_ID
-)
-private const val DATA_SORT_ORDER = "${ContactsContract.Data.MIMETYPE} asc"
-private const val DATA_MIMETYPE_INDEX = 0
-private const val DATA_LOOKUP_INDEX = 1
-private const val DATA_FIELD_INDEX = 2
-private const val DATA_ADDITIONAL_FIELD_INDEX = 3
-private const val DATA_PHOTO_ID_INDEX = 4
-
 class ContactProviderRepository(
-    private val context: Context
+    context: Context
 ) : ContactRepository {
+    private val resolverHelper = ContentResolverHelper(context)
+    private val contactPopulationConductor = ContactPopulationConductor()
+    private val simpleContactPopulationConductor = SimpleContactPopulationConductor()
+
     override suspend fun getSimpleContacts(
         query: String?,
         contactsIds: List<Long>?
     ) = withContext(Dispatchers.IO) {
-        context.contentResolver?.let { resolver ->
-            val contacts = getContactListFramework(resolver, query, contactsIds)
-            val lookupToIndex = contacts.withIndex()
-                .associate { it.value.lookup to it.index }
-            val selection = SIMPLE_DATA_SELECTION.plus(
-                lookupToIndex.keys
-                    .joinToString(
-                        prefix = "(",
-                        postfix = ")"
-                    ) { "?" }
-            )
+        val contacts = getContactListFramework(contactsIds, query)
+        val lookupToIndex = contacts.withIndex()
+            .associate { it.value.lookup to it.index }
 
-            resolver.query(
-                ContactsContract.Data.CONTENT_URI,
-                DATA_PROJECTION,
-                selection,
-                lookupToIndex.keys.toTypedArray(),
-                DATA_SORT_ORDER
-            )?.use {
-                if (it.moveToFirst()) {
-                    do {
-                        it.getStringOrNull(DATA_LOOKUP_INDEX)?.let { key ->
-                            lookupToIndex[key]
-                        }?.let(
-                            fun(i: Int) {
-                                when (
-                                    it.getStringOrNull(DATA_MIMETYPE_INDEX)
-                                ) {
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Phone
-                                        .CONTENT_ITEM_TYPE -> {
-                                        it.getStringOrNull(
-                                            DATA_FIELD_INDEX
-                                        )?.let { phone ->
-                                            contacts[i].phoneNumber = phone
-                                        }
-                                    }
-
-                                    ContactsContract
-                                        .CommonDataKinds
-                                        .Photo
-                                        .CONTENT_ITEM_TYPE -> {
-                                        it.getLongOrNull(
-                                            DATA_PHOTO_ID_INDEX
-                                        )?.let { rowPhotoId ->
-                                            if (rowPhotoId > 0) {
-                                                contacts[i].photoId =
-                                                    rowPhotoId
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        )
-                    } while (it.moveToNext())
-                }
+        resolverHelper.populateSimpleContactEntitiesInMap(lookupToIndex) {
+            getStringOrNull(DATA_LOOKUP_INDEX)?.let { key ->
+                lookupToIndex[key]
             }
-
-            contacts
+                ?.let { i ->
+                    contacts[i] = simpleContactPopulationConductor.populatorFromCursor(this)
+                        .populate(contacts[i], this)
+                }
         }
+
+        contacts
     }
 
     override suspend fun getContacts(lookups: List<String?>) =
@@ -148,197 +73,69 @@ class ContactProviderRepository(
 
     override suspend fun getContact(lookup: String) =
         withContext(Dispatchers.IO) {
-            context.contentResolver?.let { resolver ->
-                getContactId(resolver, lookup)?.let { id ->
-                    populateContactEntity(resolver, ContactEntity(id, lookup))
-                }
+            getContactId(lookup)?.let { id ->
+                populateContactEntity(ContactEntity(id, lookup))
             }
         }
 
     override suspend fun findContactById(id: Long) =
         withContext(Dispatchers.IO) {
-            context.contentResolver?.let { resolver ->
-                getContactLookup(resolver, id)?.let { lookup ->
-                    populateContactEntity(resolver, ContactEntity(id, lookup))
-                }
+            getContactLookup(id)?.let { lookup ->
+                populateContactEntity(ContactEntity(id, lookup))
             }
         }
 
     private fun getContactListFramework(
-        resolver: ContentResolver,
-        query: String?,
-        contactsIds: List<Long>?
-    ): List<SimpleContactEntity> {
+        contactsIds: List<Long>?,
+        query: String?
+    ): MutableList<SimpleContactEntity> {
         val contactList = mutableListOf<SimpleContactEntity>()
-        val (selection, selectionArgs) = contactsIds?.let {
-            "${ContactsContract.Contacts._ID} in (${it.joinToString(", ")})"
-        }
-            .let {
-                if (query == null || query.isBlank()) {
-                    it to null
-                } else {
-                    if (it == null) {
-                        SIMPLE_CONTACT_SELECTION
-                    } else {
-                        "$it and $SIMPLE_CONTACT_SELECTION"
-                    } to arrayOf("%$query%")
-                }
-            }
 
-        resolver.query(
-            ContactsContract.Contacts.CONTENT_URI,
-            CONTACT_PROJECTION,
-            selection,
-            selectionArgs,
-            CONTACT_SORT_ORDER
-        )?.use {
-            if (it.moveToFirst()) {
-                do {
-                    contactList.add(
-                        SimpleContactEntity(
-                            it.getLong(CONTACT_ID_INDEX),
-                            it.getString(CONTACT_LOOKUP_INDEX),
-                            it.getString(CONTACT_NAME_INDEX)
-                        )
-                    )
-                } while (it.moveToNext())
-            }
+        resolverHelper.getSimpleContactEntitiesByIdsAndQuery(contactsIds, query) {
+            contactList.add(
+                SimpleContactEntity(
+                    getLong(CONTACT_ID_INDEX),
+                    getString(CONTACT_LOOKUP_INDEX),
+                    getString(CONTACT_NAME_INDEX)
+                )
+            )
         }
 
         return contactList
     }
 
-    private fun getContactId(
-        resolver: ContentResolver,
-        lookup: String
-    ): Long? {
+    private fun getContactId(lookup: String): Long? {
         var id: Long? = null
 
-        resolver.query(
-            ContactsContract.Contacts.CONTENT_URI,
-            CONTACT_PROJECTION,
-            LOOKUP_SELECTION,
-            arrayOf(lookup),
-            CONTACT_SORT_ORDER
-        )?.use {
-            if (it.moveToFirst()) {
-                it.getLongOrNull(CONTACT_ID_INDEX)?.let { newId ->
-                    id = newId
-                }
+        resolverHelper.getContactByLookup(lookup) {
+            getLongOrNull(CONTACT_ID_INDEX)?.let { newId ->
+                id = newId
             }
         }
 
         return id
     }
 
-    private fun getContactLookup(
-        resolver: ContentResolver,
-        id: Long
-    ): String? {
+    private fun getContactLookup(id: Long): String? {
         var lookup: String? = null
 
-        resolver.query(
-            ContactsContract.Contacts.CONTENT_URI,
-            CONTACT_PROJECTION,
-            ID_SELECTION,
-            arrayOf(id.toString()),
-            CONTACT_SORT_ORDER
-        )?.use {
-            if (it.moveToFirst()) {
-                it.getStringOrNull(CONTACT_LOOKUP_INDEX)?.let { newLookup ->
-                    lookup = newLookup
-                }
+        resolverHelper.getContactLookupById(id) {
+            getStringOrNull(CONTACT_LOOKUP_INDEX)?.let { newLookup ->
+                lookup = newLookup
             }
         }
 
         return lookup
     }
 
-    private fun populateContactEntity(
-        resolver: ContentResolver,
-        contactEntityFramework: ContactEntity
-    ): ContactEntity {
+    private fun populateContactEntity(contactEntityFramework: ContactEntity): ContactEntity {
         var result = contactEntityFramework
-        val scheme = getPopulationScheme()
 
-        resolver.query(
-            ContactsContract.Data.CONTENT_URI,
-            DATA_PROJECTION,
-            LOOKUP_SELECTION,
-            arrayOf(contactEntityFramework.lookup),
-            null
-        )?.use {
-            if (it.moveToFirst()) {
-                do {
-                    result = scheme[it.getStringOrNull(DATA_MIMETYPE_INDEX)]
-                        ?.invoke(it, result)
-                        ?: result
-                } while (it.moveToNext())
-            }
+        resolverHelper.populateContactEntity(contactEntityFramework) {
+            result = contactPopulationConductor.populatorFromCursor(this)
+                .populate(result, this)
         }
 
         return result
     }
-
-    private fun getPopulationScheme(): HashMap<String, (Cursor, ContactEntity) -> ContactEntity> =
-        hashMapOf(
-            ContactsContract.CommonDataKinds.StructuredName
-                .CONTENT_ITEM_TYPE to { cursor, contact ->
-                cursor.getStringOrNull(DATA_FIELD_INDEX)?.let {
-                    contact.copy(name = it)
-                } ?: contact
-            },
-
-            ContactsContract.CommonDataKinds.Email
-                .CONTENT_ITEM_TYPE to { cursor, contact ->
-                cursor.getStringOrNull(DATA_FIELD_INDEX)?.let {
-                    contact.copy(emails = contact.emails.plus(it))
-                } ?: contact
-            },
-
-            ContactsContract.CommonDataKinds.Phone
-                .CONTENT_ITEM_TYPE to { cursor, contact ->
-                cursor.getStringOrNull(DATA_FIELD_INDEX)?.let {
-                    contact.copy(phones = contact.phones.plus(it))
-                } ?: contact
-            },
-
-            ContactsContract.CommonDataKinds.Note
-                .CONTENT_ITEM_TYPE to { cursor, contact ->
-                cursor.getStringOrNull(DATA_FIELD_INDEX)?.let {
-                    contact.copy(description = it)
-                } ?: contact
-            },
-
-            ContactsContract.CommonDataKinds.Event
-                .CONTENT_ITEM_TYPE to { cursor, contact ->
-                cursor.getIntOrNull(DATA_ADDITIONAL_FIELD_INDEX)
-                    ?.takeIf {
-                        it == ContactsContract.CommonDataKinds.Event
-                            .TYPE_BIRTHDAY
-                    }
-                    ?.let { _ ->
-                        cursor.getStringOrNull(DATA_FIELD_INDEX)
-                            ?.split("-")
-                            ?.reversed()
-                            ?.let {
-                                contact.copy(
-                                    birthDate = BirthDate(
-                                        it[0].toInt(),
-                                        it[1].toInt() - 1
-                                    )
-                                )
-                            }
-                    } ?: contact
-            },
-
-            ContactsContract.CommonDataKinds.Photo
-                .CONTENT_ITEM_TYPE to { cursor, contact ->
-                cursor.getLongOrNull(DATA_PHOTO_ID_INDEX)
-                    ?.takeIf { it > 0 }
-                    ?.let {
-                        contact.copy(photoId = it)
-                    } ?: contact
-            }
-        )
 }

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/ContactProviderBirthDateHelper.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/ContactProviderBirthDateHelper.kt
@@ -1,0 +1,15 @@
+package com.example.presentation.data.repositories.helpers
+
+import com.example.domain.entities.BirthDate
+
+class ContactProviderBirthDateHelper {
+    fun birthDateFromString(dateString: String) =
+        dateString.split("-")
+            .reversed()
+            .let {
+                BirthDate(
+                    it[0].toInt(),
+                    it[1].toInt()
+                )
+            }
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/ContentResolverHelper.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/ContentResolverHelper.kt
@@ -1,0 +1,141 @@
+package com.example.presentation.data.repositories.helpers
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.provider.ContactsContract
+import com.example.domain.entities.ContactEntity
+import java.lang.ref.WeakReference
+
+private val DATA_PROJECTION = arrayOf(
+    ContactsContract.Data.MIMETYPE,
+    ContactsContract.Data.LOOKUP_KEY,
+    ContactsContract.Data.DATA1,
+    ContactsContract.Data.DATA2,
+    ContactsContract.CommonDataKinds.Photo.PHOTO_FILE_ID
+)
+private const val DATA_SORT_ORDER = "${ContactsContract.Data.MIMETYPE} asc"
+
+private val CONTACT_PROJECTION = arrayOf(
+    ContactsContract.Contacts._ID,
+    ContactsContract.Contacts.LOOKUP_KEY,
+    ContactsContract.Contacts.DISPLAY_NAME_PRIMARY
+)
+private const val CONTACT_SORT_ORDER =
+    "${ContactsContract.Contacts.DISPLAY_NAME_PRIMARY} asc"
+
+private const val LOOKUP_SELECTION = "${ContactsContract.Contacts.LOOKUP_KEY} = ?"
+private const val ID_SELECTION = "${ContactsContract.Contacts._ID} = ?"
+
+class ContentResolverHelper(
+    context: Context
+) {
+    private val contextReference = WeakReference(context)
+    private val selectionHelper = SelectionHelper()
+
+    fun populateSimpleContactEntitiesInMap(
+        entities: Map<String, Int>,
+        block: Cursor.() -> Unit
+    ) = safeResolverContext {
+        val selection = selectionHelper.contactDataSelectionFromMap(entities)
+
+        query(
+            ContactsContract.Data.CONTENT_URI,
+            DATA_PROJECTION,
+            selection,
+            entities.keys.toTypedArray(),
+            DATA_SORT_ORDER
+        )?.use {
+            if (it.moveToFirst()) {
+                do {
+                    block(it)
+                } while (it.moveToNext())
+            }
+        }
+    }
+
+    fun getSimpleContactEntitiesByIdsAndQuery(
+        contactsIds: List<Long>?,
+        contactQueryString: String?,
+        block: Cursor.() -> Unit
+    ) = safeResolverContext {
+        val selection = selectionHelper.contactSelectionFromContactsIdsAndQuery(
+            contactsIds,
+            contactQueryString
+        )
+        val selectionArgs = selectionHelper.contactSelectionArgsFromContactsIdsAndQuery(
+            contactsIds,
+            contactQueryString
+        )
+
+        query(
+            ContactsContract.Contacts.CONTENT_URI,
+            CONTACT_PROJECTION,
+            selection,
+            selectionArgs,
+            CONTACT_SORT_ORDER
+        )?.use {
+            if (it.moveToFirst()) {
+                do {
+                    block(it)
+                } while (it.moveToNext())
+            }
+        }
+    }
+
+    fun getContactByLookup(lookup: String, block: Cursor.() -> Unit) = safeResolverContext {
+        query(
+            ContactsContract.Contacts.CONTENT_URI,
+            CONTACT_PROJECTION,
+            LOOKUP_SELECTION,
+            arrayOf(lookup),
+            CONTACT_SORT_ORDER
+        )?.use {
+            if (it.moveToFirst()) {
+                block(it)
+            }
+        }
+    }
+
+    fun populateContactEntity(
+        contactEntityFramework: ContactEntity,
+        block: Cursor.() -> Unit
+    ) = safeResolverContext {
+        query(
+            ContactsContract.Data.CONTENT_URI,
+            DATA_PROJECTION,
+            LOOKUP_SELECTION,
+            arrayOf(contactEntityFramework.lookup),
+            null
+        )?.use {
+            if (it.moveToFirst()) {
+                do {
+                    block(it)
+                } while (it.moveToNext())
+            }
+        }
+    }
+
+    fun getContactLookupById(id: Long, block: Cursor.() -> Unit) = safeResolverContext {
+        query(
+            ContactsContract.Contacts.CONTENT_URI,
+            CONTACT_PROJECTION,
+            ID_SELECTION,
+            arrayOf(id.toString()),
+            CONTACT_SORT_ORDER
+        )?.use {
+            if (it.moveToFirst()) {
+                block(it)
+            }
+        }
+    }
+
+    private inline fun safeResolverContext(block: ContentResolver.() -> Unit) {
+        val dereferencedContext = contextReference.get() ?: throw IllegalStateException(
+            "${this::class.simpleName} must have a valid context instance"
+        )
+
+        dereferencedContext.contentResolver
+            ?.let(block)
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/SelectionHelper.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/SelectionHelper.kt
@@ -1,0 +1,72 @@
+package com.example.presentation.data.repositories.helpers
+
+import android.provider.ContactsContract
+
+private const val SIMPLE_CONTACT_SELECTION =
+    "${ContactsContract.Contacts.DISPLAY_NAME} like ?"
+private const val CONTACT_DATA_SELECTION =
+    "${ContactsContract.Data.MIMETYPE} in ('" +
+        ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE +
+        "', '${ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE}" +
+        "') and ${ContactsContract.Data.LOOKUP_KEY} in "
+
+class SelectionHelper {
+    fun contactDataSelectionFromMap(map: Map<*, *>) = contactDataSelectionFromIterable(map.values)
+
+    fun contactDataSelectionFromIterable(iterable: Iterable<*>) = buildString {
+        append(CONTACT_DATA_SELECTION)
+        append(selectionInClauseFromIterable(iterable))
+    }
+
+    fun contactSelectionFromContactsIdsAndQuery(
+        contactsIds: Collection<Long>?,
+        query: String?
+    ) = buildString {
+        val querySpecified = query != null && query.isNotBlank()
+
+        if (contactsIds != null) {
+            val idColumn = ContactsContract.Contacts._ID
+            val idValues = selectionInClauseFromIterable(contactsIds)
+
+            append("$idColumn in $idValues")
+
+            if (querySpecified) {
+                append(" and ")
+            }
+        }
+
+        if (querySpecified) {
+            append(SIMPLE_CONTACT_SELECTION)
+        }
+    }
+
+    fun contactSelectionArgsFromContactsIdsAndQuery(
+        contactsIds: Collection<Long>?,
+        query: String?
+    ): Array<String> {
+        val contactIdInClauseArgs = contactsIds?.map { it.toString() } ?: emptyList()
+
+        return if (query != null && query.isNotBlank()) {
+            contactIdInClauseArgs.plus(query).toTypedArray()
+        } else {
+            contactIdInClauseArgs.toTypedArray()
+        }
+    }
+
+    private fun selectionInClauseFromIterable(iterable: Iterable<*>) = buildString {
+        append('(')
+
+        var hasMarksBefore = false
+        iterable.forEach { _ ->
+            if (hasMarksBefore) {
+                append(',')
+            } else {
+                hasMarksBefore = true
+            }
+
+            append('?')
+        }
+
+        append(')')
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/ContactPopulationConductor.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/ContactPopulationConductor.kt
@@ -1,0 +1,51 @@
+package com.example.presentation.data.repositories.helpers.populators
+
+import android.database.Cursor
+import android.provider.ContactsContract
+import androidx.core.database.getStringOrNull
+import com.example.presentation.data.repositories.helpers.populators.contact.ContactBirthdayPopulator
+import com.example.presentation.data.repositories.helpers.populators.contact.ContactDescriptionPopulator
+import com.example.presentation.data.repositories.helpers.populators.contact.ContactEmailPopulator
+import com.example.presentation.data.repositories.helpers.populators.contact.ContactNamePopulator
+import com.example.presentation.data.repositories.helpers.populators.contact.ContactPhonePopulator
+import com.example.presentation.data.repositories.helpers.populators.contact.ContactPhotoPopulator
+import com.example.presentation.data.repositories.helpers.populators.contact.NullContactPopulator
+
+const val DATA_MIMETYPE_INDEX = 0
+const val DATA_LOOKUP_INDEX = 1
+const val DATA_FIELD_INDEX = 2
+const val DATA_ADDITIONAL_FIELD_INDEX = 3
+const val DATA_PHOTO_ID_INDEX = 4
+
+class ContactPopulationConductor {
+    private val nullPopulator = NullContactPopulator()
+    private val map = mapOf(
+        ContactsContract.CommonDataKinds
+            .StructuredName
+            .CONTENT_ITEM_TYPE to ContactNamePopulator(),
+
+        ContactsContract.CommonDataKinds
+            .Email
+            .CONTENT_ITEM_TYPE to ContactEmailPopulator(),
+
+        ContactsContract.CommonDataKinds
+            .Phone
+            .CONTENT_ITEM_TYPE to ContactPhonePopulator(),
+
+        ContactsContract.CommonDataKinds
+            .Note
+            .CONTENT_ITEM_TYPE to ContactDescriptionPopulator(),
+
+        ContactsContract.CommonDataKinds
+            .Event
+            .CONTENT_ITEM_TYPE to ContactBirthdayPopulator(),
+
+        ContactsContract.CommonDataKinds
+            .Photo
+            .CONTENT_ITEM_TYPE to ContactPhotoPopulator()
+    )
+
+    fun populatorFromCursor(cursor: Cursor) = map.get(
+        cursor.getStringOrNull(DATA_MIMETYPE_INDEX)
+    ) ?: nullPopulator
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/SimpleContactPopulationConductor.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/SimpleContactPopulationConductor.kt
@@ -1,0 +1,25 @@
+package com.example.presentation.data.repositories.helpers.populators
+
+import android.database.Cursor
+import android.provider.ContactsContract
+import androidx.core.database.getStringOrNull
+import com.example.presentation.data.repositories.helpers.populators.simplecontact.NullSimpleContactPopulator
+import com.example.presentation.data.repositories.helpers.populators.simplecontact.SimpleContactPhonePopulator
+import com.example.presentation.data.repositories.helpers.populators.simplecontact.SimpleContactPhotoPopulator
+
+class SimpleContactPopulationConductor {
+    private val nullPopulator = NullSimpleContactPopulator()
+    private val map = mapOf(
+        ContactsContract.CommonDataKinds
+            .Phone
+            .CONTENT_ITEM_TYPE to SimpleContactPhonePopulator(),
+
+        ContactsContract.CommonDataKinds
+            .Photo
+            .CONTENT_ITEM_TYPE to SimpleContactPhotoPopulator()
+    )
+
+    fun populatorFromCursor(cursor: Cursor) = map.get(
+        cursor.getStringOrNull(DATA_MIMETYPE_INDEX)
+    ) ?: nullPopulator
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactBirthdayPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactBirthdayPopulator.kt
@@ -1,0 +1,29 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import android.provider.ContactsContract
+import androidx.core.database.getIntOrNull
+import androidx.core.database.getStringOrNull
+import com.example.domain.entities.ContactEntity
+import com.example.presentation.data.repositories.helpers.ContactProviderBirthDateHelper
+import com.example.presentation.data.repositories.helpers.populators.DATA_ADDITIONAL_FIELD_INDEX
+import com.example.presentation.data.repositories.helpers.populators.DATA_FIELD_INDEX
+
+class ContactBirthdayPopulator : ContactPopulator {
+    private val birthdayHelper = ContactProviderBirthDateHelper()
+
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor) =
+        cursor.getIntOrNull(DATA_ADDITIONAL_FIELD_INDEX)
+            ?.takeIf { eventType ->
+                eventType == ContactsContract.CommonDataKinds
+                    .Event
+                    .TYPE_BIRTHDAY
+            }
+            ?.let { _ -> cursor.getStringOrNull(DATA_FIELD_INDEX) }
+            ?.let { birthdayString ->
+                contactEntity.copy(
+                    birthDate = birthdayHelper.birthDateFromString(birthdayString)
+                )
+            }
+            ?: contactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactDescriptionPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactDescriptionPopulator.kt
@@ -1,0 +1,15 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import androidx.core.database.getStringOrNull
+import com.example.domain.entities.ContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_FIELD_INDEX
+
+class ContactDescriptionPopulator : ContactPopulator {
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor) =
+        cursor.getStringOrNull(DATA_FIELD_INDEX)
+            ?.let {
+                contactEntity.copy(description = it)
+            }
+            ?: contactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactEmailPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactEmailPopulator.kt
@@ -1,0 +1,15 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import androidx.core.database.getStringOrNull
+import com.example.domain.entities.ContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_FIELD_INDEX
+
+class ContactEmailPopulator : ContactPopulator {
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor) =
+        cursor.getStringOrNull(DATA_FIELD_INDEX)
+            ?.let {
+                contactEntity.copy(emails = contactEntity.emails.plus(it))
+            }
+            ?: contactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactNamePopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactNamePopulator.kt
@@ -1,0 +1,15 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import androidx.core.database.getStringOrNull
+import com.example.domain.entities.ContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_FIELD_INDEX
+
+class ContactNamePopulator : ContactPopulator {
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor) =
+        cursor.getStringOrNull(DATA_FIELD_INDEX)
+            ?.let {
+                contactEntity.copy(name = it)
+            }
+            ?: contactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactPhonePopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactPhonePopulator.kt
@@ -1,0 +1,15 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import androidx.core.database.getStringOrNull
+import com.example.domain.entities.ContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_FIELD_INDEX
+
+class ContactPhonePopulator : ContactPopulator {
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor) =
+        cursor.getStringOrNull(DATA_FIELD_INDEX)
+            ?.let {
+                contactEntity.copy(phones = contactEntity.phones.plus(it))
+            }
+            ?: contactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactPhotoPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactPhotoPopulator.kt
@@ -1,0 +1,16 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import androidx.core.database.getLongOrNull
+import com.example.domain.entities.ContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_PHOTO_ID_INDEX
+
+class ContactPhotoPopulator : ContactPopulator {
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor) =
+        cursor.getLongOrNull(DATA_PHOTO_ID_INDEX)
+            ?.takeIf { it > 0 }
+            ?.let {
+                contactEntity.copy(photoId = it)
+            }
+            ?: contactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/ContactPopulator.kt
@@ -1,0 +1,8 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import com.example.domain.entities.ContactEntity
+
+interface ContactPopulator {
+    fun populate(contactEntity: ContactEntity, cursor: Cursor): ContactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/NullContactPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/contact/NullContactPopulator.kt
@@ -1,0 +1,10 @@
+package com.example.presentation.data.repositories.helpers.populators.contact
+
+import android.database.Cursor
+import com.example.domain.entities.ContactEntity
+
+class NullContactPopulator : ContactPopulator {
+    override fun populate(contactEntity: ContactEntity, cursor: Cursor): ContactEntity {
+        return contactEntity
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/NullSimpleContactPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/NullSimpleContactPopulator.kt
@@ -1,0 +1,13 @@
+package com.example.presentation.data.repositories.helpers.populators.simplecontact
+
+import android.database.Cursor
+import com.example.domain.entities.SimpleContactEntity
+
+class NullSimpleContactPopulator : SimpleContactPopulator {
+    override fun populate(
+        simpleContactEntity: SimpleContactEntity,
+        cursor: Cursor
+    ): SimpleContactEntity {
+        return simpleContactEntity
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/SimpleContactPhonePopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/SimpleContactPhonePopulator.kt
@@ -1,0 +1,19 @@
+package com.example.presentation.data.repositories.helpers.populators.simplecontact
+
+import android.database.Cursor
+import androidx.core.database.getStringOrNull
+import com.example.domain.entities.SimpleContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_FIELD_INDEX
+
+class SimpleContactPhonePopulator : SimpleContactPopulator {
+    override fun populate(
+        simpleContactEntity: SimpleContactEntity,
+        cursor: Cursor
+    ) = cursor.getStringOrNull(DATA_FIELD_INDEX)
+        ?.let { phone ->
+            simpleContactEntity.copy(
+                phoneNumber = phone
+            )
+        }
+        ?: simpleContactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/SimpleContactPhotoPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/SimpleContactPhotoPopulator.kt
@@ -1,0 +1,18 @@
+package com.example.presentation.data.repositories.helpers.populators.simplecontact
+
+import android.database.Cursor
+import androidx.core.database.getLongOrNull
+import com.example.domain.entities.SimpleContactEntity
+import com.example.presentation.data.repositories.helpers.populators.DATA_PHOTO_ID_INDEX
+
+class SimpleContactPhotoPopulator : SimpleContactPopulator {
+    override fun populate(
+        simpleContactEntity: SimpleContactEntity,
+        cursor: Cursor
+    ) = cursor.getLongOrNull(DATA_PHOTO_ID_INDEX)
+        ?.takeIf { it > 0 }
+        ?.let { photoId ->
+            simpleContactEntity.copy(photoId = photoId)
+        }
+        ?: simpleContactEntity
+}

--- a/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/SimpleContactPopulator.kt
+++ b/presentation/src/main/java/com/example/presentation/data/repositories/helpers/populators/simplecontact/SimpleContactPopulator.kt
@@ -1,0 +1,11 @@
+package com.example.presentation.data.repositories.helpers.populators.simplecontact
+
+import android.database.Cursor
+import com.example.domain.entities.SimpleContactEntity
+
+interface SimpleContactPopulator {
+    fun populate(
+        simpleContactEntity: SimpleContactEntity,
+        cursor: Cursor
+    ): SimpleContactEntity
+}


### PR DESCRIPTION
Продолжение недавно начавшейся в этом репозитории тенденции очищать старый код.
На этот раз в прицеле оказался `ContactProviderRepository`.

Репозиторий стал утилизировать `ContentResolverHelper`, который управляет запросами к `ContactProvider` и передвижением курсора по строкам, на каждой из которых срабатывает хук - клиент может взять со строчки данные.
`ContentResolverHelper`, в свою очередь, использует `SelectionHelper`, который специализируется на построении запросов и массивов аргументов к ним.

В некоторых случаях репозиторий делегирует получение данных из строки различным `Populator`ам. Реализации `ContactPopulator` обрабатывают `ContactEntity`, а реализации `SimpleContactPopulator`, соответственно, `SimpleContactEntity`. Ответственность выбора реализации `Populator`а в зависимости от mimetype строки лежит на `ContactPopulationConductor` и `SimpleContactPopulationConductor`, к которым репозиторий и обращается.

Отдельно стоит отметить и `ContactProviderBirthDateHelper`. К нему обращается `ContactBirthdayPopulator`, чтобы перевести внутреннее строковое представление даты провайдера контактов в `BirthDate`.